### PR TITLE
Add Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ language: python
 python:
     - "2.6"
     - "2.7"
+    - "3.3"
+    - "3.4"
+    - "pypy"
 install: "pip install -r requirements.txt --use-mirrors"
 script:
-  - nosetests --with-coverage --cover-package=querylist
+  - python setup.py nosetests
 after_success:
   coveralls

--- a/querylist/__init__.py
+++ b/querylist/__init__.py
@@ -1,7 +1,8 @@
 """QueryList provides a simple way to filter lists of objects."""
+from __future__ import absolute_import
 
-from querylist import QueryList
-from betterdict import BetterDict
+from .querylist import QueryList
+from .betterdict import BetterDict
 
 __version__ = "0.2.0"
 __author__ = "Thomas Welfley"

--- a/querylist/querylist.py
+++ b/querylist/querylist.py
@@ -1,5 +1,9 @@
-from betterdict import BetterDict
-from fieldlookup import field_lookup
+from __future__ import absolute_import
+
+from six import iteritems
+
+from .betterdict import BetterDict
+from .fieldlookup import field_lookup
 
 
 class QueryList(list):
@@ -72,7 +76,7 @@ class QueryList(list):
         object.
 
         """
-        for q, val in lookup_strings.iteritems():
+        for q, val in iteritems(lookup_strings):
             if not field_lookup(instance, q, val, True):
                 return False
 

--- a/querylist/tests/betterdict_dict_tests.py
+++ b/querylist/tests/betterdict_dict_tests.py
@@ -1,9 +1,15 @@
-import unittest2
+from __future__ import absolute_import
+
+try:
+    from unittest2 import TestCase
+except ImportError:
+    from unittest import TestCase
+
 
 from querylist import BetterDict
 
 
-class BetterDictActsAsDict(unittest2.TestCase):
+class BetterDictActsAsDict(TestCase):
     """BetterDicts should act just like dictionaries"""
     def setUp(self):
         self.src_dict = {

--- a/querylist/tests/betterdict_tests.py
+++ b/querylist/tests/betterdict_tests.py
@@ -1,5 +1,11 @@
+from __future__ import absolute_import
+
+try:
+    from unittest2 import TestCase
+except ImportError:
+    from unittest import TestCase
+
 from copy import deepcopy
-import unittest2
 
 from querylist import BetterDict
 
@@ -24,7 +30,7 @@ SRC_DICT = {
 }
 
 
-class BetterDictTestCase(unittest2.TestCase):
+class BetterDictTestCase(TestCase):
     def setUp(self):
         self.src_dict = deepcopy(SRC_DICT)
         self.better_dict = BetterDict(self.src_dict)

--- a/querylist/tests/betterdictlookup_tests.py
+++ b/querylist/tests/betterdictlookup_tests.py
@@ -1,9 +1,14 @@
-import unittest2
+from __future__ import absolute_import
+
+try:
+    from unittest2 import TestCase
+except ImportError:
+    from unittest import TestCase
 
 from querylist.betterdict import BetterDictLookUp
 
 
-class BetterDictLookUpInstancesCan(unittest2.TestCase):
+class BetterDictLookUpInstancesCan(TestCase):
     def setUp(self):
         self.src_dict = {
             'foo': 1,

--- a/querylist/tests/comparator_tests.py
+++ b/querylist/tests/comparator_tests.py
@@ -1,11 +1,16 @@
-import unittest2
+from __future__ import absolute_import
+
+try:
+    from unittest2 import TestCase
+except ImportError:
+    from unittest import TestCase
 
 from querylist.fieldlookup import FieldLookup
 
 fl = FieldLookup
 
 
-class ExactTests(unittest2.TestCase):
+class ExactTests(TestCase):
     """FieldLookup.exact()"""
     def test_returns_true_if_passed_values_match_exactly(self):
         self.assertTrue(fl.exact(1, 1))
@@ -14,7 +19,7 @@ class ExactTests(unittest2.TestCase):
         self.assertFalse(fl.exact(1, 2))
 
 
-class IExactTests(unittest2.TestCase):
+class IExactTests(TestCase):
     """FieldLookup.iexact()"""
     def test_returns_true_if_case_insensitive_values_match(self):
         self.assertTrue(fl.iexact('Yay', 'yay'))
@@ -23,7 +28,7 @@ class IExactTests(unittest2.TestCase):
         self.assertFalse(fl.iexact('yay', 'foo'))
 
 
-class ContainsTests(unittest2.TestCase):
+class ContainsTests(TestCase):
     """FieldLookup.contains()"""
     def test_returns_true_if_first_value_contains_second_value(self):
         self.assertTrue(fl.contains('go team', 'team'))
@@ -35,7 +40,7 @@ class ContainsTests(unittest2.TestCase):
         self.assertFalse(fl.contains([1, 2], 3))
 
 
-class IContainsTests(unittest2.TestCase):
+class IContainsTests(TestCase):
     """FieldLookup.icontains()"""
     def test_returns_true_if_first_value_contains_second_with_any_case(self):
         self.assertTrue(fl.icontains('FLOrida', 'flo'))
@@ -44,7 +49,7 @@ class IContainsTests(unittest2.TestCase):
         self.assertFalse(fl.icontains('Florida', 'Cal'))
 
 
-class InTests(unittest2.TestCase):
+class InTests(TestCase):
     """FieldLookup.in()"""
     def test_returns_true_if_first_value_is_in_second_value(self):
         self.assertTrue(fl.isin(1, [1, 2]))
@@ -53,7 +58,7 @@ class InTests(unittest2.TestCase):
         self.assertFalse(fl.isin(4, [1, 2]))
 
 
-class StartsWithTests(unittest2.TestCase):
+class StartsWithTests(TestCase):
     """FieldLookup.startswith()"""
     def test_returns_true_if_first_value_starts_with_second_value(self):
         self.assertTrue(fl.startswith('kittens', 'kitten'))
@@ -62,7 +67,7 @@ class StartsWithTests(unittest2.TestCase):
         self.assertFalse(fl.startswith('kittens', 'do'))
 
 
-class IStartsWithTests(unittest2.TestCase):
+class IStartsWithTests(TestCase):
     """FieldLookup.istartswith()"""
     def test_lowercase_vals_and_return_true_if_first_starts_with_second(self):
         self.assertTrue(fl.istartswith('Kittens', 'kitteN'))
@@ -71,7 +76,7 @@ class IStartsWithTests(unittest2.TestCase):
         self.assertFalse(fl.istartswith('Kittens', 'DOG'))
 
 
-class EndsWithTests(unittest2.TestCase):
+class EndsWithTests(TestCase):
     """FieldLookup.endswith()"""
     def test_returns_true_if_first_value_ends_with_second_value(self):
         self.assertTrue(fl.endswith('kittens', 'tens'))
@@ -80,7 +85,7 @@ class EndsWithTests(unittest2.TestCase):
         self.assertFalse(fl.endswith('kittens', 'do'))
 
 
-class IEndsWithTests(unittest2.TestCase):
+class IEndsWithTests(TestCase):
     """FieldLookup.iendswith()"""
     def test_lowercase_vals_and_return_true_if_first_ends_with_second(self):
         self.assertTrue(fl.iendswith('Kittens', 'teNs'))
@@ -89,7 +94,7 @@ class IEndsWithTests(unittest2.TestCase):
         self.assertFalse(fl.iendswith('Kittens', 'DOG'))
 
 
-class RegexTests(unittest2.TestCase):
+class RegexTests(TestCase):
     """FieldLookup.regex()"""
     def test_returns_true_if_first_value_matches_regex(self):
         self.assertTrue(fl.regex('foo', r'\w*'))
@@ -98,7 +103,7 @@ class RegexTests(unittest2.TestCase):
         self.assertFalse(fl.regex('foo', r'\w*BOOP'))
 
 
-class IRegexWithTests(unittest2.TestCase):
+class IRegexWithTests(TestCase):
     """FieldLookup.iregex()"""
     def test_returns_true_if_first_value_matches_iregex(self):
         self.assertTrue(fl.iregex('foo', r'[A-Z]*'))
@@ -107,7 +112,7 @@ class IRegexWithTests(unittest2.TestCase):
         self.assertFalse(fl.iregex('foo', r'[A-Z]*BOOP'))
 
 
-class GTTests(unittest2.TestCase):
+class GTTests(TestCase):
     """FieldLookup.gt()"""
     def test_returns_true_if_first_value_is_greater_than_second(self):
         self.assertTrue(fl.gt(2, 1))
@@ -119,7 +124,7 @@ class GTTests(unittest2.TestCase):
         self.assertFalse(fl.gt(2, 2))
 
 
-class GTETests(unittest2.TestCase):
+class GTETests(TestCase):
     """FieldLookup.gte()"""
     def test_returns_true_if_first_value_is_greater_than_second(self):
         self.assertTrue(fl.gte(2, 1))
@@ -131,7 +136,7 @@ class GTETests(unittest2.TestCase):
         self.assertFalse(fl.gte(1, 2))
 
 
-class LTTests(unittest2.TestCase):
+class LTTests(TestCase):
     """FieldLookup.lt()"""
     def test_returns_true_if_first_value_is_less_than_second(self):
         self.assertTrue(fl.lt(1, 2))
@@ -143,7 +148,7 @@ class LTTests(unittest2.TestCase):
         self.assertFalse(fl.lt(2, 2))
 
 
-class LTETests(unittest2.TestCase):
+class LTETests(TestCase):
     """FieldLookup.lte()"""
     def test_returns_true_if_first_value_is_less_than_second(self):
         self.assertTrue(fl.lte(1, 2))

--- a/querylist/tests/fieldlookup_tests.py
+++ b/querylist/tests/fieldlookup_tests.py
@@ -1,10 +1,15 @@
-import unittest2
+from __future__ import absolute_import
+
+try:
+    from unittest2 import TestCase
+except ImportError:
+    from unittest import TestCase
 
 from querylist import BetterDict
 from querylist.fieldlookup import FieldLookup, field_lookup
 
 
-class FieldLookupTests(unittest2.TestCase):
+class FieldLookupTests(TestCase):
     def setUp(self):
         self.fl = FieldLookup()
         self.instance = BetterDict({
@@ -24,32 +29,30 @@ class FieldLookupTests(unittest2.TestCase):
 class FieldLookupParseLookupTests(FieldLookupTests):
     """FieldLookups._parse_lookup_string()"""
     def test_returns_single_value_list_for_simple_lookups(self):
-        self.assertEquals(self.fl._parse_lookup_string('yay')[0], ['yay'])
+        self.assertEqual(self.fl._parse_lookup_string('yay')[0], ['yay'])
 
     def test_splits_relational_lookups_properly(self):
-        self.assertEquals(
+        self.assertEqual(
             self.fl._parse_lookup_string('yay__bar')[0], ['yay', 'bar'])
 
     def test_defaults_to_exact_for_the_lookup_method(self):
-        self.assertEquals(
+        self.assertEqual(
             self.fl._parse_lookup_string('yay')[1], self.fl.exact)
 
     def test_correctly_determines_the_lookup_method_if_not_the_default(self):
-        self.assertEquals(
+        self.assertEqual(
             self.fl._parse_lookup_string('yay__iexact')[1], self.fl.iexact)
 
 
 class FiedLookupResolveLookupChainTests(FieldLookupTests):
     """FieldLookup._resolve_lookup_chain()"""
     def test_returns_the_correct_value_for_simple_lookup_chains(self):
-        self.assertEquals(
+        self.assertEqual(
             self.fl._resolve_lookup_chain(['foo'], self.instance), 1)
 
     def test_returns_the_correct_value_for_multli_link_lookup_chains(self):
-        self.assertEquals(
-            self.fl._resolve_lookup_chain(['bar', 'dog'], self.instance),
-            False
-        )
+        self.assertFalse(
+            self.fl._resolve_lookup_chain(['bar', 'dog'], self.instance))
 
 
 class FieldLookupCallTests(FieldLookupTests):

--- a/querylist/tests/querylist_list_tests.py
+++ b/querylist/tests/querylist_list_tests.py
@@ -1,9 +1,14 @@
-import unittest2
+from __future__ import absolute_import
+
+try:
+    from unittest2 import TestCase
+except ImportError:
+    from unittest import TestCase
 
 from querylist import BetterDict, QueryList
 
 
-class QueryListAddition(unittest2.TestCase):
+class QueryListAddition(TestCase):
     """QueryList Addition"""
     def setUp(self):
         self.src_list1 = [{'foo': 1}, {'foo': 2}, {'foo': 3}]
@@ -39,7 +44,7 @@ class QueryListAddition(unittest2.TestCase):
             [{'foo': 2}, {'foo': 4}, {'foo': 6}])
 
 
-class QueryListActsAsList(unittest2.TestCase):
+class QueryListActsAsList(TestCase):
     """QueryLists should act just like lists if the wrapper is compatible
     with the src data elements"""
     def setUp(self):

--- a/querylist/tests/querylist_tests.py
+++ b/querylist/tests/querylist_tests.py
@@ -1,11 +1,17 @@
-import unittest2
+from __future__ import absolute_import
 
-from fixtures import SITE_LIST
+try:
+    from unittest2 import TestCase
+except ImportError:
+    from unittest import TestCase
+
 from querylist import QueryList, BetterDict
 from querylist.querylist import NotFound
 
+from .fixtures import SITE_LIST
 
-class QueryListInstantiationTests(unittest2.TestCase):
+
+class QueryListInstantiationTests(TestCase):
     """QueryList instantiation"""
     def test_sets_wrapper_attribute_to_BetterDict_by_default(self):
         self.assertEqual(QueryList()._wrapper, BetterDict)
@@ -23,7 +29,7 @@ class QueryListInstantiationTests(unittest2.TestCase):
         self.assertEqual(QueryList([1, 2, 3], str, False), [1, 2, 3])
 
 
-class QueryListConverIterableTests(unittest2.TestCase):
+class QueryListConverIterableTests(TestCase):
     """QueryList._convert_iterable()"""
     def setUp(self):
         self.iterable = [{'foo': 1}, {'bar': 2}]
@@ -38,7 +44,7 @@ class QueryListConverIterableTests(unittest2.TestCase):
         self.assertEqual(ql._convert_iterable(self.iterable), self.iterable)
 
 
-class QueryListCheckElementTests(unittest2.TestCase):
+class QueryListCheckElementTests(TestCase):
     "QueryList._check_element()"
     def setUp(self):
         self.ql = QueryList()
@@ -54,7 +60,7 @@ class QueryListCheckElementTests(unittest2.TestCase):
         self.assertTrue(self.ql._check_element({'id': 1, 'dog': 4}, self.bd))
 
 
-class QueryListMethodTests(unittest2.TestCase):
+class QueryListMethodTests(TestCase):
     def setUp(self):
         self.src_list = SITE_LIST
         self.ql = QueryList(SITE_LIST)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
+six==1.9.0
+
 # Testing requirements.
 coveralls==0.4.1
 flake8==2.3.0
 frosted==1.4.1
-nose==1.2.1
-pinocchio==0.3.1
+nose==1.3.6
 pep257==0.4.1
-unittest2==0.5.1
+spec==1.2.2
 testtube==1.0.0
 
 # Documentation requirements.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [nosetests]
-with-spec=1
-spec-color=1
+with-specplugin=1
+with-coverage=1
+cover-package=querylist

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,45 @@
+import ast
+import re
 import sys
 
 from setuptools import setup, find_packages
 
-from querylist import __version__, __author__
+unittest2_module = 'unittest2>=0.5.1,<0.6'
 
-unittest2_module = 'unittest2==0.5.1'
-
-# If we're using Python 3, unittest2 won't work. We need unittest2py3k
+# If we're using Python 3, we don't need unittest2.
 if sys.version_info > (3, 0):
-    unittest2_module = 'unittest2py3k==0.5.1'
+    unittest2_module = ''
+
+_version_re = re.compile(r'__version__\s+=\s+(.*)')
+
+with open('querylist/__init__.py', 'rb') as f:
+    version = str(ast.literal_eval(_version_re.search(
+        f.read().decode('utf-8')).group(1)))
 
 setup(
-    name="querylist",
-    version=__version__,
+    name='querylist',
+    version=version,
     url='https://github.com/thomasw/querylist',
     download_url='https://github.com/thomasw/querylist/downloads',
-    author=__author__,
+    author='Thomas Welfley',
     author_email='thomas.welfley+querylist@gmail.com',
     description='This package provides a QueryList class with django '
                 'ORM-esque filtering, excluding, and getting for lists. It '
                 'also provides BetterDict, a dot lookup/assignment capable '
                 'wrapper for dicts that is 100% backwards compatible.',
     packages=find_packages(),
-    tests_require=["nose==1.2.1", "pinocchio==0.3.1", unittest2_module],
+    install_requires=[
+        'six>=1.9.0,<1.10',
+    ],
+    tests_require=[
+        'nose>=1.3.6,<1.4',
+        'spec>=1.2.2,<1.3',
+        unittest2_module],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Topic :: Software Development :: Libraries',
     ],
-    test_suite='nose.collector'
+    test_suite='nose.collector',
 )


### PR DESCRIPTION
This commit adds Python 3.3 and 3.4 support. It was originally gonna
drop Python 2.6 support, but it can easily be simultaneously supported.

The biggest influence in the diff is changes to absolute imports and
dropping the explicit use of unittest2, since imports changed with
python 3 and unittest2 is no longer needed.

The small changes to `setup.py` and `setup.cfg` are related and all were
needed for the code to all work, so I thought it fit better within a
single commit.

I added `six` as a requirement since it made using `iteritems` still
work on dictionary items.

I changed from `pinocchio` to `spec` since it was the only used part of
`pinocchio` and it was the only one that had Python 3 support when I
first looked.

The requirement for `six` means that `querylist` can no longer be
imported easily in `setup.py` without the outer virtualenv/python having
six installed, and the only value that changed often was the version,
so I used the code @mitsuhiko's `click` uses for reading the
`__version__` from the `__init__.py` file.

I also dropped the requirement for `unittest2py3k` since it isn't
needed by Python 3 anymore, and I changed the `assertEquals` to
`assertEqual` since the former is being deprecated, which is the only
change that could've probably gone in a separate commit.