### PR TITLE
NotFound exception improvements

### DIFF
--- a/querylist/list.py
+++ b/querylist/list.py
@@ -108,7 +108,8 @@ class QueryList(list):
             if self._check_element(kwargs, x):
                 return x
 
-        raise NotFound("Element with specified attributes not found.")
+        raise QueryList.NotFound(
+            "Element with specified attributes not found.")
 
     def exclude(self, **kwargs):
         """Generates a QueryList containing the subset of objects from
@@ -166,6 +167,5 @@ class QueryList(list):
             data=(x for x in self if self._check_element(kwargs, x)),
             wrapper=self._wrapper, wrap=False)
 
-
-class NotFound(Exception):
-    pass
+    class NotFound(Exception):
+        pass

--- a/querylist/list.py
+++ b/querylist/list.py
@@ -99,17 +99,18 @@ class QueryList(list):
         >>> site_list.get(id=None)
         Traceback (most recent call last):
           File "<stdin>", line 1, in <module>
-          File "querylist/querylist.py", line 55, in get
-        querylist.querylist.NotFound: Element with specified attributes not
-        found.
+          File "querylist/list.py", line 113, in get
+            "Element not found with attributes: %s" % kv_str)
+        querylist.list.NotFound: Element not found with attributes: id=None
 
         """
         for x in self:
             if self._check_element(kwargs, x):
                 return x
 
+        kv_str = self._stringify_kwargs(kwargs)
         raise QueryList.NotFound(
-            "Element with specified attributes not found.")
+            "Element not found with attributes: %s" % kv_str)
 
     def exclude(self, **kwargs):
         """Generates a QueryList containing the subset of objects from
@@ -166,6 +167,9 @@ class QueryList(list):
         return QueryList(
             data=(x for x in self if self._check_element(kwargs, x)),
             wrapper=self._wrapper, wrap=False)
+
+    def _stringify_kwargs(self, kwargs):
+        return ', '.join('%s=%s' % kv for kv in kwargs.items())
 
     class NotFound(Exception):
         pass

--- a/tests/querylist_tests.py
+++ b/tests/querylist_tests.py
@@ -1,5 +1,4 @@
 from querylist import QueryList, BetterDict
-from querylist.list import NotFound
 
 from tests.base import TestCase
 from tests.fixtures import SITE_LIST
@@ -75,7 +74,7 @@ class QueryListGetMethodTests(QueryListMethodTests):
         self.assertEqual(self.ql.get(), self.src_list[0])
 
     def test_raises_an_exception_if_no_matches_are_found(self):
-        self.assertRaises(NotFound, self.ql.get, url='github.com')
+        self.assertRaises(QueryList.NotFound, self.ql.get, url='github.com')
 
     def test_works_correctly_with_multiple_lookups(self):
         self.assertEqual(


### PR DESCRIPTION
This adds some import sugar, it's nice to import just `QueryList`.

Not having to import `NotFound` also makes it easier to upgrade if/when `QueryList` ever needs to move again (since the exceptions will travel too).

Added a bit more context in the exception message, kinda like how KeyError does it:
```
>>> thomas['heart']
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
KeyError: 'heart'
>>>
>>> friends.get(name='Vargas')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "querylist/list.py", line 113, in get
    "Element not found with attributes: %s" % kv_str)
querylist.list.NotFound: Element not found with attributes: name=Vargas
```
