### PR TITLE
Fix issue with building the wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,10 @@ from setuptools import setup, find_packages
 import querylist
 
 
-unittest2_module = ''
+tests_require = [
+    'nose>=1.3.6,<1.4',
+    'spec>=1.2.2,<1.3',
+]
 
 if sys.version_info < (2, 7):
     # spec causes python setup.py test to fail. This import fixes that for
@@ -13,8 +16,7 @@ if sys.version_info < (2, 7):
     import multiprocessing  # noqa
 
     # If we're still on python 2.6, we need unittest2
-    unittest2_module = 'unittest2<1.2'
-
+    tests_require.append('unittest2<1.2')
 
 setup(
     name='querylist',
@@ -28,11 +30,7 @@ setup(
                 'also provides BetterDict, a dot lookup/assignment capable '
                 'wrapper for dicts that is 100% backwards compatible.',
     packages=find_packages(),
-    tests_require=[
-        'nose>=1.3.6,<1.4',
-        'spec>=1.2.2,<1.3',
-        unittest2_module
-    ],
+    tests_require=tests_require,
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
The build trips on an empty string requirement, throwing:
```
$ python setup.py sdist bdist_wheel
...
ValueError: ('No requirements found', '')
```